### PR TITLE
Adjust opening quantity calculation

### DIFF
--- a/shop/api/get_daily_summary.php
+++ b/shop/api/get_daily_summary.php
@@ -104,8 +104,8 @@ if ($stock_data) {
     $quantity_sold = (int)$stock_data['quantity_sold'];
     $quantity_adjusted = (int)$stock_data['quantity_adjusted'];
 
-    $stock_data['opening_quantity'] = $closing_quantity - ($quantity_added - $quantity_sold - $quantity_adjusted);
-    $stock_data['total_moved'] = $quantity_added + $quantity_sold + $quantity_adjusted;
+    $stock_data['opening_quantity'] = $closing_quantity - $quantity_added + $quantity_sold - $quantity_adjusted;
+    $stock_data['total_moved'] = $quantity_added + $quantity_sold + abs($quantity_adjusted);
     $response['stock_summary'] = $stock_data;
 } else {
         $response['stock_summary'] = ['opening_quantity' => 0, 'quantity_sold' => 0, 'quantity_added' => 0, 'quantity_adjusted' => 0, 'closing_quantity' => 0, 'total_moved' => 0];


### PR DESCRIPTION
## Summary
- correct opening quantity formula to account for stock adjustments
- include absolute stock adjustments in total movement

## Testing
- `php -l shop/api/get_daily_summary.php`


------
https://chatgpt.com/codex/tasks/task_b_689dd49eb3a08328ba2aaf9ededf3c17