### PR TITLE
refactor: centralize db config and fix stock summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Shop Module Supplies
+
+## Configuration
+
+Set the following environment variables before running the application:
+
+- `DB_HOST`
+- `DB_NAME`
+- `DB_USER`
+- `DB_PASS`
+- `DB_PORT` (optional, defaults to `3306`)
+- `DB_CHARSET` (optional, defaults to `utf8mb4`)
+- `DB_TIMEZONE` (optional, defaults to `+02:00`)
+
+The application reads these variables in `shop/config.php` to establish database connections.

--- a/shop/api/add_petty_cash_expense.php
+++ b/shop/api/add_petty_cash_expense.php
@@ -31,9 +31,9 @@ if (empty($description)) {
 }
 
 // --- 2. Database Connection ---
-$host = 'srv582.hstgr.io'; $user = 'u789944046_socrates'; $pass = 'Naho1386'; $name = 'u789944046_suppliesdirect';
+require_once __DIR__ . '/../config.php';
 try {
-    $pdo = new PDO("mysql:host=$host;dbname=$name;charset=utf8mb4", $user, $pass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+    $pdo = getPDO();
 } catch (PDOException $e) {
     http_response_code(500);
     echo json_encode(['error' => 'Database connection failed.']);

--- a/shop/api/add_product.php
+++ b/shop/api/add_product.php
@@ -15,10 +15,14 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
 }
 
 // --- DB Connection ---
-$host = 'srv582.hstgr.io'; $dbname = 'u789944046_suppliesdirect'; $user = 'u789944046_socrates'; $pass = 'Naho1386'; $charset = 'utf8mb4';
-$dsn = "mysql:host=$host;dbname=$dbname;charset=$charset";
-$options = [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION, PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC];
-try { $pdo = new PDO($dsn, $user, $pass, $options); } catch (\PDOException $e) { http_response_code(500); echo json_encode(['error' => 'Database error.']); exit(); }
+require_once __DIR__ . '/../config.php';
+try {
+    $pdo = getPDO();
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Database error.']);
+    exit();
+}
 
 // --- Get and Validate Data ---
 $sku = trim($_POST['new_product_sku'] ?? '');

--- a/shop/api/add_transaction.php
+++ b/shop/api/add_transaction.php
@@ -16,10 +16,14 @@ if (!isset($_SESSION['user_id']) || !isset($_SESSION['shop_id'])) {
 }
 
 // --- DB Connection ---
-$host = 'srv582.hstgr.io'; $dbname = 'u789944046_suppliesdirect'; $user = 'u789944046_socrates'; $pass = 'Naho1386'; $charset = 'utf8mb4';
-$dsn = "mysql:host=$host;dbname=$dbname;charset=$charset";
-$options = [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION, PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC];
-try { $pdo = new PDO($dsn, $user, $pass, $options); } catch (\PDOException $e) { http_response_code(500); echo json_encode(['error' => 'Database error.']); exit(); }
+require_once __DIR__ . '/../config.php';
+try {
+    $pdo = getPDO();
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Database error.']);
+    exit();
+}
 
 // --- Get Data and Session Info ---
 $shop_id = $_SESSION['shop_id'];

--- a/shop/api/get_cash_details.php
+++ b/shop/api/get_cash_details.php
@@ -20,9 +20,9 @@ if (!preg_match("/^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$/", $date
 }
 
 // --- Database Connection ---
-$host = 'srv582.hstgr.io'; $user = 'u789944046_socrates'; $pass = 'Naho1386'; $name = 'u789944046_suppliesdirect';
+require_once __DIR__ . '/../config.php';
 try {
-    $pdo = new PDO("mysql:host=$host;dbname=$name;charset=utf8mb4", $user, $pass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION, PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC]);
+    $pdo = getPDO();
 } catch (PDOException $e) {
     http_response_code(500);
     echo json_encode(['error' => 'Database connection failed.']);

--- a/shop/api/get_daily_summary.php
+++ b/shop/api/get_daily_summary.php
@@ -22,10 +22,14 @@ if (!preg_match("/^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$/", $date
 }
 
 // --- DB Connection ---
-$host = 'srv582.hstgr.io'; $user = 'u789944046_socrates'; $pass = 'Naho1386'; $name = 'u789944046_suppliesdirect';
+require_once __DIR__ . '/../config.php';
 try {
-    $pdo = new PDO("mysql:host=$host;dbname=$name;charset=utf8mb4", $user, $pass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION, PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC]);
-} catch (PDOException $e) { /* ... DB error handling ... */ http_response_code(500); echo json_encode(['error' => 'DB Connection Failed.']); exit(); }
+    $pdo = getPDO();
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['error' => 'DB Connection Failed.']);
+    exit();
+}
 
 $response = [
     'financial_summary' => null,
@@ -103,9 +107,11 @@ if ($stock_data) {
     $quantity_added = (int)$stock_data['quantity_added'];
     $quantity_sold = (int)$stock_data['quantity_sold'];
     $quantity_adjusted = (int)$stock_data['quantity_adjusted'];
+    $quantity_adjusted_abs = abs($quantity_adjusted);
 
-    $stock_data['opening_quantity'] = $closing_quantity - ($quantity_added - $quantity_sold - $quantity_adjusted);
-    $stock_data['total_moved'] = $quantity_added + $quantity_sold + $quantity_adjusted;
+    $stock_data['opening_quantity'] = $closing_quantity - $quantity_added + $quantity_sold - $quantity_adjusted;
+    $stock_data['total_moved'] = $quantity_added + $quantity_sold + $quantity_adjusted_abs;
+    $stock_data['quantity_adjusted'] = $quantity_adjusted_abs;
     $response['stock_summary'] = $stock_data;
 } else {
         $response['stock_summary'] = ['opening_quantity' => 0, 'quantity_sold' => 0, 'quantity_added' => 0, 'quantity_adjusted' => 0, 'closing_quantity' => 0, 'total_moved' => 0];

--- a/shop/api/get_daily_transactions.php
+++ b/shop/api/get_daily_transactions.php
@@ -22,10 +22,14 @@ if (!preg_match("/^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$/", $date
 }
 
 // --- DB Connection ---
-$host = 'srv582.hstgr.io'; $dbname = 'u789944046_suppliesdirect'; $user = 'u789944046_socrates'; $pass = 'Naho1386'; $charset = 'utf8mb4';
-$dsn = "mysql:host=$host;dbname=$dbname;charset=$charset";
-$options = [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION, PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC, PDO::ATTR_EMULATE_PREPARES => false];
-try { $pdo = new PDO($dsn, $user, $pass, $options); } catch (\PDOException $e) { http_response_code(500); echo json_encode(['error' => 'Database connection failed.']); exit(); }
+require_once __DIR__ . '/../config.php';
+try {
+    $pdo = getPDO();
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Database connection failed.']);
+    exit();
+}
 
 $response = [];
 

--- a/shop/api/get_financial_summary.php
+++ b/shop/api/get_financial_summary.php
@@ -20,9 +20,9 @@ if (!preg_match("/^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$/", $date
 }
 
 // --- Database Connection ---
-$host = 'srv582.hstgr.io'; $user = 'u789944046_socrates'; $pass = 'Naho1386'; $name = 'u789944046_suppliesdirect';
+require_once __DIR__ . '/../config.php';
 try {
-    $pdo = new PDO("mysql:host=$host;dbname=$name;charset=utf8mb4", $user, $pass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION, PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC]);
+    $pdo = getPDO();
 } catch (PDOException $e) {
     http_response_code(500);
     echo json_encode(['error' => 'Database connection failed.']);

--- a/shop/api/get_stock_details.php
+++ b/shop/api/get_stock_details.php
@@ -28,9 +28,9 @@ if (!$product_id) {
 }
 
 // --- DB Connection ---
-$host = 'srv582.hstgr.io'; $user = 'u789944046_socrates'; $pass = 'Naho1386'; $name = 'u789944046_suppliesdirect';
+require_once __DIR__ . '/../config.php';
 try {
-    $pdo = new PDO("mysql:host=$host;dbname=$name;charset=utf8mb4", $user, $pass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION, PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC]);
+    $pdo = getPDO();
 } catch (PDOException $e) {
     http_response_code(500);
     echo json_encode(['error' => 'DB Connection Failed.']);

--- a/shop/api/get_transaction_details.php
+++ b/shop/api/get_transaction_details.php
@@ -10,10 +10,14 @@ if (!isset($_SESSION['user_id']) || !isset($_SESSION['shop_id'])) {
 }
 
 // --- DB Connection ---
-$host = 'srv582.hstgr.io'; $dbname = 'u789944046_suppliesdirect'; $user = 'u789944046_socrates'; $pass = 'Naho1386'; $charset = 'utf8mb4';
-$dsn = "mysql:host=$host;dbname=$dbname;charset=$charset";
-$options = [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION, PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC];
-try { $pdo = new PDO($dsn, $user, $pass, $options); } catch (\PDOException $e) { http_response_code(500); echo json_encode(['error' => 'Database error.']); exit(); }
+require_once __DIR__ . '/../config.php';
+try {
+    $pdo = getPDO();
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Database error.']);
+    exit();
+}
 
 // --- Get Parameters ---
 $shop_id = $_SESSION['shop_id'];

--- a/shop/api/search_products.php
+++ b/shop/api/search_products.php
@@ -12,10 +12,14 @@ if (!isset($_SESSION['user_id'], $_SESSION['shop_id'])) {
 $shop_id = (int)$_SESSION['shop_id'];
 $term = $_GET['term'] ?? '';
 
-$host = 'srv582.hstgr.io'; $user = 'u789944046_socrates'; $pass = 'Naho1386'; $name = 'u789944046_suppliesdirect';
+require_once __DIR__ . '/../config.php';
 try {
-    $pdo = new PDO("mysql:host=$host;dbname=$name;charset=utf8mb4", $user, $pass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION, PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC]);
-} catch (PDOException $e) { http_response_code(500); echo json_encode([]); exit(); }
+    $pdo = getPDO();
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode([]);
+    exit();
+}
 
 // Query to find products in the current shop that match the search term
 $sql = "

--- a/shop/api/update_opening_balance.php
+++ b/shop/api/update_opening_balance.php
@@ -35,9 +35,9 @@ if (empty($admin_username) || empty($admin_password) || empty($date)) {
 }
 
 // --- 2. Database Connection ---
-$host = 'srv582.hstgr.io'; $user = 'u789944046_socrates'; $pass = 'Naho1386'; $name = 'u789944046_suppliesdirect';
+require_once __DIR__ . '/../config.php';
 try {
-    $pdo = new PDO("mysql:host=$host;dbname=$name;charset=utf8mb4", $user, $pass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+    $pdo = getPDO();
 } catch (PDOException $e) {
     http_response_code(500);
     echo json_encode(['error' => 'Database connection failed.']);

--- a/shop/complete_sale.php
+++ b/shop/complete_sale.php
@@ -6,17 +6,11 @@ header('Content-Type: application/json');
 session_start();
 
 // --- 2. DATABASE CONNECTION ---
-// Make sure these credentials are correct for your environment
-// --- 1. DATABASE CONNECTION ---
-$db_host = 'srv582.hstgr.io';
-$db_user = 'u789944046_socrates';
-$db_pass = 'Naho1386'; // Your password
-$db_name = 'u789944046_suppliesdirect';
-$db_port = 3306;
+require_once __DIR__ . '/config.php';
 
 // Enable error reporting to catch all issues during the transaction
 mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
-$mysqli = new mysqli($db_host, $db_user, $db_pass, $db_name, $db_port);
+$mysqli = getMySQLi();
 
 // --- 3. GET AND VALIDATE INPUT ---
 $json_data = file_get_contents('php://input');

--- a/shop/config.php
+++ b/shop/config.php
@@ -1,0 +1,31 @@
+<?php
+function getPDO() {
+    $host = getenv('DB_HOST');
+    $name = getenv('DB_NAME');
+    $user = getenv('DB_USER');
+    $pass = getenv('DB_PASS');
+    $charset = getenv('DB_CHARSET') ?: 'utf8mb4';
+    $dsn = "mysql:host=$host;dbname=$name;charset=$charset";
+    $options = [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    ];
+    return new PDO($dsn, $user, $pass, $options);
+}
+
+function getMySQLi() {
+    $host = getenv('DB_HOST');
+    $name = getenv('DB_NAME');
+    $user = getenv('DB_USER');
+    $pass = getenv('DB_PASS');
+    $port = getenv('DB_PORT') ?: 3306;
+    $conn = new mysqli($host, $user, $pass, $name, $port);
+    if ($conn->connect_error) {
+        die("Database Connection Failed: " . $conn->connect_error);
+    }
+    $conn->set_charset('utf8mb4');
+    $timezone = getenv('DB_TIMEZONE') ?: '+02:00';
+    $conn->query("SET time_zone = '$timezone'");
+    return $conn;
+}
+

--- a/shop/daily_report.php
+++ b/shop/daily_report.php
@@ -6,10 +6,12 @@ if (!isset($_SESSION['user_id']) || !isset($_SESSION['warehouse_id'])) {
 }
 
 // --- DB Connection ---
-$host = 'srv582.hstgr.io'; $dbname = 'u789944046_suppliesdirect'; $user = 'u789944046_socrates'; $pass = 'Naho1386'; $charset = 'utf8mb4';
-$dsn = "mysql:host=$host;dbname=$dbname;charset=$charset";
-$options = [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION, PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC, PDO::ATTR_EMULATE_PREPARES => false];
-try { $pdo = new PDO($dsn, $user, $pass, $options); } catch (\PDOException $e) { throw new \PDOException($e->getMessage(), (int)$e->getCode()); }
+require_once __DIR__ . '/config.php';
+try {
+    $pdo = getPDO();
+} catch (PDOException $e) {
+    throw new PDOException($e->getMessage(), (int)$e->getCode());
+}
 
 $user_id = $_SESSION['user_id'];
 $warehouse_id = $_SESSION['warehouse_id'];

--- a/shop/db_connect.php
+++ b/shop/db_connect.php
@@ -1,31 +1,10 @@
 <?php
 // db_connect.php
 
-// --- Database Configuration ---
-// These are your correct credentials. Do not change them.
-$db_host = 'srv582.hstgr.io';
-$db_name = 'u789944046_suppliesdirect';
-$db_user = 'u789944046_socrates';
-$db_pass = 'Naho1386';
-$db_port = 3306; // Default MySQL port
+require_once __DIR__ . '/config.php';
 
 // --- Create Connection ---
-$conn = new mysqli($db_host, $db_user, $db_pass, $db_name, $db_port);
-
-// --- Check Connection ---
-if ($conn->connect_error) {
-    die("Database Connection Failed: " . $conn->connect_error);
-}
-
-// Set charset to utf8mb4 for full Unicode support
-$conn->set_charset("utf8mb4");
-
-// =======================================================================
-// --- THIS IS THE NEW, REQUIRED LINE ---
-// It synchronizes the database session timezone with your application's timezone.
-// Replace 'Africa/Blantyre' with your actual server/business timezone if different.
-$conn->query("SET time_zone = '+02:00'");
-// =======================================================================
+$conn = getMySQLi();
 
 
 /**

--- a/shop/generate_transfer_note.php
+++ b/shop/generate_transfer_note.php
@@ -6,23 +6,11 @@ if (!isset($_SESSION['user_id']) || !isset($_SESSION['warehouse_id'])) {
 }
 
 // --- DB Connection ---
-// (Your DB connection block remains here)
-$host = 'srv582.hstgr.io';
-$dbname = 'u789944046_suppliesdirect';
-$user = 'u789944046_socrates';
-$pass = 'Naho1386'; 
-$charset = 'utf8mb4';
-
-$dsn = "mysql:host=$host;dbname=$dbname;charset=$charset";
-$options = [
-    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
-    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-    PDO::ATTR_EMULATE_PREPARES   => false,
-];
+require_once __DIR__ . '/config.php';
 try {
-     $pdo = new PDO($dsn, $user, $pass, $options);
-} catch (\PDOException $e) {
-     throw new \PDOException($e->getMessage(), (int)$e->getCode());
+    $pdo = getPDO();
+} catch (PDOException $e) {
+    throw new PDOException($e->getMessage(), (int)$e->getCode());
 }
 // --- End of DB Connection ---
 

--- a/shop/item_balance_report.php
+++ b/shop/item_balance_report.php
@@ -3,10 +3,12 @@ session_start();
 if (!isset($_SESSION['user_id']) || !isset($_SESSION['warehouse_id'])) { header('Location: /login.php'); exit(); }
 
 // --- DB Connection ---
-$host = 'srv582.hstgr.io'; $dbname = 'u789944046_suppliesdirect'; $user = 'u789944046_socrates'; $pass = 'Naho1386'; $charset = 'utf8mb4';
-$dsn = "mysql:host=$host;dbname=$dbname;charset=$charset";
-$options = [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION, PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC, PDO::ATTR_EMULATE_PREPARES => false];
-try { $pdo = new PDO($dsn, $user, $pass, $options); } catch (\PDOException $e) { throw new \PDOException($e->getMessage(), (int)$e->getCode()); }
+require_once __DIR__ . '/config.php';
+try {
+    $pdo = getPDO();
+} catch (PDOException $e) {
+    throw new PDOException($e->getMessage(), (int)$e->getCode());
+}
 
 $user_id = $_SESSION['user_id'];
 $warehouse_id = $_SESSION['warehouse_id'];

--- a/shop/process_grn.php
+++ b/shop/process_grn.php
@@ -20,10 +20,12 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
 }
 
 // --- DB Connection ---
-$host = 'srv582.hstgr.io'; $dbname = 'u789944046_suppliesdirect'; $user = 'u789944046_socrates'; $pass = 'Naho1386'; $charset = 'utf8mb4';
-$dsn = "mysql:host=$host;dbname=$dbname;charset=$charset";
-$options = [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION, PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC, PDO::ATTR_EMULATE_PREPARES => false];
-try { $pdo = new PDO($dsn, $user, $pass, $options); } catch (\PDOException $e) { die("Database connection failed: " . $e->getMessage()); }
+require_once __DIR__ . '/config.php';
+try {
+    $pdo = getPDO();
+} catch (PDOException $e) {
+    die("Database connection failed: " . $e->getMessage());
+}
 
 
 // 2. --- DATA EXTRACTION AND VALIDATION ---

--- a/shop/search_products.php
+++ b/shop/search_products.php
@@ -16,15 +16,10 @@ if (!isset($_SESSION['shop_id']) || empty($_SESSION['shop_id'])) {
 
 $current_shop_id = (int)$_SESSION['shop_id'];
 
-// --- Database Connection (remains the same) ---
-$db_host = 'srv582.hstgr.io';
-$db_name = 'u789944046_suppliesdirect';
-$db_user = 'u789944046_socrates';
-$db_pass = 'Naho1386';
-
+// --- Database Connection ---
+require_once __DIR__ . '/config.php';
 try {
-    $pdo = new PDO("mysql:host=$db_host;dbname=$db_name;charset=utf8mb4", $db_user, $db_pass);
-    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    $pdo = getPDO();
 } catch (PDOException $e) {
     http_response_code(500);
     echo json_encode(['error' => 'Database connection failed.']);

--- a/shop/start_of_day.php
+++ b/shop/start_of_day.php
@@ -13,10 +13,10 @@ $shopId = (int)$_SESSION['shop_id'];
 $today = date('Y-m-d');
 $yesterday = date('Y-m-d', strtotime('-1 day'));
 
-// DB Connection (Use your live credentials)
-$db_host = 'srv582.hstgr.io'; $db_user = 'u789944046_socrates'; $db_pass = 'Naho1386'; $db_name = 'u789944046_suppliesdirect'; $db_port = 3306;
+// DB Connection
+require_once __DIR__ . '/config.php';
 mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
-$mysqli = new mysqli($db_host, $db_user, $db_pass, $db_name, $db_port);
+$mysqli = getMySQLi();
 echo "Connected to database successfully.\n";
 
 // --- 2. START THE TRANSACTION ---

--- a/shop/stock_requests.php
+++ b/shop/stock_requests.php
@@ -8,12 +8,12 @@ if (!isset($_SESSION['user_id'])) {
 }
 
 // --- Database Connection ---
-$host = 'srv582.hstgr.io'; $dbname = 'u789944046_suppliesdirect'; $user = 'u789944046_socrates'; $pass = 'Naho1386'; $charset = 'utf8mb4';
-$dsn = "mysql:host=$host;dbname=$dbname;charset=$charset";
-$options = [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION, PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC, PDO::ATTR_EMULATE_PREPARES => false];
+require_once __DIR__ . '/config.php';
 try {
-    $pdo = new PDO($dsn, $user, $pass, $options);
-} catch (\PDOException $e) { throw new \PDOException($e->getMessage(), (int)$e->getCode()); }
+    $pdo = getPDO();
+} catch (PDOException $e) {
+    throw new PDOException($e->getMessage(), (int)$e->getCode());
+}
 // --- End DB Connection ---
 
 $user_id = $_SESSION['user_id'];

--- a/shop/warehouse_dashboard.php
+++ b/shop/warehouse_dashboard.php
@@ -6,10 +6,12 @@ if (!isset($_SESSION['user_id']) || !isset($_SESSION['warehouse_id'])) {
 }
 
 // --- DB Connection ---
-$host = 'srv582.hstgr.io'; $dbname = 'u789944046_suppliesdirect'; $user = 'u789944046_socrates'; $pass = 'Naho1386'; $charset = 'utf8mb4';
-$dsn = "mysql:host=$host;dbname=$dbname;charset=$charset";
-$options = [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION, PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC, PDO::ATTR_EMULATE_PREPARES => false];
-try { $pdo = new PDO($dsn, $user, $pass, $options); } catch (\PDOException $e) { throw new \PDOException($e->getMessage(), (int)$e->getCode()); }
+require_once __DIR__ . '/config.php';
+try {
+    $pdo = getPDO();
+} catch (PDOException $e) {
+    throw new PDOException($e->getMessage(), (int)$e->getCode());
+}
 
 $user_id = $_SESSION['user_id'];
 $warehouse_id = $_SESSION['warehouse_id'];

--- a/shop/warehouse_inventory.php
+++ b/shop/warehouse_inventory.php
@@ -6,14 +6,12 @@ if (!isset($_SESSION['user_id']) || !isset($_SESSION['warehouse_id'])) {
 }
 
 // DB Connection...
-$host = 'srv582.hstgr.io';
-$dbname = 'u789944046_suppliesdirect';
-$user = 'u789944046_socrates';
-$pass = 'Naho1386'; 
-$charset = 'utf8mb4';
-$dsn = "mysql:host=$host;dbname=$dbname;charset=$charset";
-$options = [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION, PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC, PDO::ATTR_EMULATE_PREPARES => false];
-try { $pdo = new PDO($dsn, $user, $pass, $options); } catch (\PDOException $e) { throw new \PDOException($e->getMessage(), (int)$e->getCode()); }
+require_once __DIR__ . '/config.php';
+try {
+    $pdo = getPDO();
+} catch (PDOException $e) {
+    throw new PDOException($e->getMessage(), (int)$e->getCode());
+}
 
 $user_id = $_SESSION['user_id'];
 $warehouse_id = $_SESSION['warehouse_id'];

--- a/shop/warehouse_requests.php
+++ b/shop/warehouse_requests.php
@@ -6,23 +6,11 @@ if (!isset($_SESSION['user_id']) || !isset($_SESSION['warehouse_id'])) {
 }
 
 // --- DB Connection ---
-// (Your existing DB connection code remains here)
-$host = 'srv582.hstgr.io';
-$dbname = 'u789944046_suppliesdirect';
-$user = 'u789944046_socrates';
-$pass = 'Naho1386'; 
-$charset = 'utf8mb4';
-
-$dsn = "mysql:host=$host;dbname=$dbname;charset=$charset";
-$options = [
-    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
-    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-    PDO::ATTR_EMULATE_PREPARES   => false,
-];
+require_once __DIR__ . '/config.php';
 try {
-     $pdo = new PDO($dsn, $user, $pass, $options);
-} catch (\PDOException $e) {
-     throw new \PDOException($e->getMessage(), (int)$e->getCode());
+     $pdo = getPDO();
+} catch (PDOException $e) {
+     throw new PDOException($e->getMessage(), (int)$e->getCode());
 }
 // --- End of DB Connection ---
 


### PR DESCRIPTION
## Summary
- compute opening quantity correctly and include absolute adjustments in daily stock summary
- load database credentials from environment variables via new config loader
- document required DB environment variables

## Testing
- `php -l shop/api/add_petty_cash_expense.php`
- `php -l shop/api/add_product.php`
- `php -l shop/api/add_transaction.php`
- `php -l shop/api/get_cash_details.php`
- `php -l shop/api/get_daily_summary.php`
- `php -l shop/api/get_daily_transactions.php`
- `php -l shop/api/get_financial_summary.php`
- `php -l shop/api/get_stock_details.php`
- `php -l shop/api/get_transaction_details.php`
- `php -l shop/api/search_products.php`
- `php -l shop/api/update_opening_balance.php`
- `php -l shop/complete_sale.php`
- `php -l shop/daily_report.php`
- `php -l shop/db_connect.php`
- `php -l shop/generate_transfer_note.php`
- `php -l shop/item_balance_report.php`
- `php -l shop/process_grn.php`
- `php -l shop/search_products.php`
- `php -l shop/start_of_day.php`
- `php -l shop/stock_requests.php`
- `php -l shop/warehouse_dashboard.php`
- `php -l shop/warehouse_inventory.php`
- `php -l shop/warehouse_requests.php`


------
https://chatgpt.com/codex/tasks/task_b_689dcfb18dd083289b0bd8e63b8788d2